### PR TITLE
Adiciona teste de carga/desempenho

### DIFF
--- a/locust_fullteaching.py
+++ b/locust_fullteaching.py
@@ -1,0 +1,19 @@
+from locust import HttpLocust, TaskSet, constant, task 
+import random
+
+class UserBehavior(TaskSet):
+    
+    headers = {
+      'content-type': 'application/json',
+    }
+
+    @task()
+    def create_user(self):
+        email = "aluno{0}@gmail.com".format(random.randint(1,100000))
+        payload = json.dumps([email,"P4ssw0rd!","Aluno","captcha"])
+        res = self.client.post("/api-users/new", data=payload, headers=self.headers, verify=False)
+
+
+class WebsiteUser(HttpLocust):
+    task_set = UserBehavior
+    wait_time = constant(1)


### PR DESCRIPTION
Usei o Locust (https://locust.io/) para fazer o teste de sistema. 
**Parâmetros utilizados:**

- 50 usuários
- 2 por segundo
- Endpoint de criação de usuário

**Resultados:**
_Em relação à carga:_
Após 1min, a aplicação não aguentou o volume de usuários simultâneos e parou completamente. Isso é visível nos gráficos abaixo:

![image](https://user-images.githubusercontent.com/17554341/91646159-9783b400-ea22-11ea-9504-8c6590135c84.png)
![image](https://user-images.githubusercontent.com/17554341/91646171-b7b37300-ea22-11ea-82e0-42da50f3d387.png)
(o response time estava na casa das centenas de ms, e quando a aplicação parou, mudou muito o eixo do gráfico por causa do timeout)
![image](https://user-images.githubusercontent.com/17554341/91646179-d285e780-ea22-11ea-8642-dc5e0758f0dd.png)

_Em relação ao desempenho:_
Os tempos de resposta da aplicação estavam um pouco altos do que se espera de uma aplicação rodando localmente em uma máquina com bastante recurso:
![image](https://user-images.githubusercontent.com/17554341/91646188-f6e1c400-ea22-11ea-813a-fc55a5cb3cf1.png)
O tempo máximo de resposta foi o timeout da aplicação
